### PR TITLE
Bump cx_Freeze version to 6.11+

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 pylint = "*"
 mypy = "*"
-cx-freeze = ">=6.2"
+cx-freeze = ">=6.11,<6.13"
 autopep8 = "*"
 
 [packages]

--- a/Readme.md
+++ b/Readme.md
@@ -23,3 +23,9 @@ On the first run, if no configuration can be found, configuration files will be 
 Download the source and install the requirements with `pipenv install --python 3`. Python 3.7+ and Pipenv have to be installed. Afterwards run with `pipenv run python main.py`.
 
 On Linux, the configuration files will be created in `~/.config/TheWitcher3ModManager`, and `wine` has to be available to run Script Merger.
+
+### Build Developed Versions (Windows)
+
+Download the source and install the requirements with `pipenv install --python 3 --dev`. Python 3.7+ and Pipenv have to be installed. Afterwards run with `pipenv run python setup.py build_exe`.
+
+The files will be created in `build/exe.[platform identifier].[python version]`.

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,8 @@
 from cx_Freeze import setup, Executable
 from src.globals.constants import *
 
-import distutils
-import opcode
-import os
-
-# opcode is not a virtualenv module, so we can use it to find the stdlib; this is the same
-# trick used by distutils itself it installs itself into the virtualenv
-distutils_path = os.path.join(os.path.dirname(opcode.__file__), 'distutils')
-
 FILES = ["res/", "translations/", "tools/",
-         (distutils_path, 'lib/distutils'), ("res/qt.conf", "qt.conf"), "LICENSE"]
+         ("res/qt.conf", "qt.conf"), "LICENSE"]
 SHORTCUT_TABLE = [
     (
         "DesktopShortcut",        # Shortcut
@@ -44,7 +36,8 @@ setup(
             "include_files": FILES,
             "excludes": ["distutils", "patool", "pyunpack"],
             "optimize": 2,
-            "zip_include_packages": ["src"]
+            "zip_include_packages": ["src"],
+            "include_msvcr": True
         },
         "bdist_msi": BDIST_MSI_OPTIONS},
     author=AUTHORS[1],


### PR DESCRIPTION
The old versions of `cx_Freeze` package rely on `bdist_msi` of `distutils` package to generate the executable. However, the newer versions of python [deprecate](https://bugs.python.org/issue39586) the `bdist_msi`. The `bdist_msi.py` may not present in some newer builds. The `cx_Freeze` package [borrows](https://github.com/marcelotduarte/cx_Freeze/pull/1447) the `bdist_msi.py` of Python 3.8 in [Version 6.11](https://cx-freeze.readthedocs.io/en/latest/releasenotes.html#version-6-11-june-2022). Therefore, `cx_Freeze` is better updating to newer version. In addition to solving the dependency missing, the hack of `setup.py` to include `distutils` can be removed.

The reason I restricted the cx-freeze version <6.13 is that version 6.13 doesn't copy `python38.dll` and `python.dll` to the build directory. The executable will report error when these two files don't exist.