### PR TITLE
Add custom script merger command support for Unix-Like OSes

### DIFF
--- a/src/configuration/config.py
+++ b/src/configuration/config.py
@@ -321,6 +321,10 @@ class Configuration:
     def gamelaunchcommand(self):
         return self.get("PATHS", "gamelaunchcommand")
 
+    @property
+    def mergerlaunchcommand(self):
+        return self.get("PATHS", "mergerlaunchcommand")
+
     def saveWindowSettings(self, ui: QWidget, window: QMainWindow):
         self.set('WINDOW', 'width', str(window.width()))
         self.set('WINDOW', 'height', str(window.height()))

--- a/src/gui/main_widget.py
+++ b/src/gui/main_widget.py
@@ -1079,7 +1079,11 @@ class CustomMainWidget(QWidget):
             if platform == "win32" or platform == "cygwin":
                 subprocess.Popen([scriptmergerpath], cwd=directory)
             elif platform == "linux" or platform == "darwin":
-                subprocess.Popen(["wine", scriptmergerpath], cwd=directory)
+                if data.config.mergerlaunchcommand:
+                    subprocess.Popen(
+                        data.config.mergerlaunchcommand, cwd=directory, shell=True)
+                else:
+                    subprocess.Popen(["wine", scriptmergerpath], cwd=directory)
             else:
                 MessageUnsupportedOSAction("")
         except Exception as err:


### PR DESCRIPTION
Allows for a custom command to launch script merger using the shell (sh) which lets you set temporary environment variables (like setting WINEPREFIX), use a custom executable (like a specific wine version), custom arguments, etc.

There are alternative options available to implement this feature, but the simplest and most flexible is a custom command.

Config key added is `mergerlaunchcommand` which is similar to the already existing `gamelaunchcommand`.

Addresses #23