### PR TITLE
Fix 7z and rar extraction on Unix-like OSes

### DIFF
--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -274,7 +274,7 @@ def extractArchive(modPath: str) -> str:
         try:
             import shutil
             shutil.unpack_archive(modPath, extractedDir)
-        except ValueError:
+        except (ValueError, shutil.ReadError):
             import patoolib  # type: ignore
             patoolib.extract_archive(
                 modPath, outdir=extractedDir, interactive=False)


### PR DESCRIPTION
The shutil module documentation says it gives a `ValueError` if it can't find a registered unpacker, but this only applies if you are specifying a format argument. If you don't specify a format, then shutil actually gives a `shutil.ReadError` when it can't detect the archive format.

Addresses #46 