### PR TITLE
Input settings regex fix

### DIFF
--- a/src/configuration/config.py
+++ b/src/configuration/config.py
@@ -321,6 +321,10 @@ class Configuration:
     def gamelaunchcommand(self):
         return self.get("PATHS", "gamelaunchcommand")
 
+    @property
+    def mergerlaunchcommand(self):
+        return self.get("PATHS", "mergerlaunchcommand")
+
     def saveWindowSettings(self, ui: QWidget, window: QMainWindow):
         self.set('WINDOW', 'width', str(window.width()))
         self.set('WINDOW', 'height', str(window.height()))

--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -274,7 +274,7 @@ def extractArchive(modPath: str) -> str:
         try:
             import shutil
             shutil.unpack_archive(modPath, extractedDir)
-        except ValueError:
+        except (ValueError, shutil.ReadError):
             import patoolib  # type: ignore
             patoolib.extract_archive(
                 modPath, outdir=extractedDir, interactive=False)

--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -21,7 +21,7 @@ from src.util.util import (
 
 XMLPATTERN = re.compile(r"<Var.+\/>", re.UNICODE)
 INPUTPATTERN = re.compile(
-    r"(\[.*\]\s*(IK_.+=\(Action=.+\)\s*)+\s*)+", re.UNICODE)
+    r"(\[.*\]\s*((IK_.+=\(Action=.+\)|Version=\d+)\s*)*\s*)+", re.UNICODE)
 USERPATTERN = re.compile(r"(\[.*\]\s*(.*=(?!.*(\(|\))).*\s*)+)+", re.UNICODE)
 INPUT_XML_PATTERN = r'id="PCInput".+<!--\s*\[BASE_CharacterMovement\]\s*-->'
 

--- a/src/gui/main_widget.py
+++ b/src/gui/main_widget.py
@@ -1079,7 +1079,11 @@ class CustomMainWidget(QWidget):
             if platform == "win32" or platform == "cygwin":
                 subprocess.Popen([scriptmergerpath], cwd=directory)
             elif platform == "linux" or platform == "darwin":
-                subprocess.Popen(["wine", scriptmergerpath], cwd=directory)
+                if data.config.mergerlaunchcommand:
+                    subprocess.Popen(
+                        data.config.mergerlaunchcommand, cwd=directory, shell=True)
+                else:
+                    subprocess.Popen(["wine", scriptmergerpath], cwd=directory)
             else:
                 MessageUnsupportedOSAction("")
         except Exception as err:


### PR DESCRIPTION
The current regex pattern for input settings matching does not match empty contexts and a `Version=##` line. This leads to W3MM ignoring the remaining parts of the file if it comes across one of those.

The new regex I have made just adds those matching capabilities to prevent breakage from missing contexts/keys.

Addresses: #48 