### PR TITLE
Fix input settings regex to match empty contexts and version

### DIFF
--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -21,7 +21,7 @@ from src.util.util import (
 
 XMLPATTERN = re.compile(r"<Var.+\/>", re.UNICODE)
 INPUTPATTERN = re.compile(
-    r"(\[.*\]\s*(IK_.+=\(Action=.+\)\s*)+\s*)+", re.UNICODE)
+    r"(\[.*\]\s*((IK_.+=\(Action=.+\)|Version=\d+)\s*)*\s*)+", re.UNICODE)
 USERPATTERN = re.compile(r"(\[.*\]\s*(.*=(?!.*(\(|\))).*\s*)+)+", re.UNICODE)
 INPUT_XML_PATTERN = r'id="PCInput".+<!--\s*\[BASE_CharacterMovement\]\s*-->'
 


### PR DESCRIPTION
The current regex pattern for input settings matching does not match empty contexts and a `Version=##` line. This leads to W3MM ignoring the remaining parts of the file if it comes across one of those.

The new regex I have made just adds those matching capabilities to prevent breakage from missing contexts/keys.

Addresses: #48

Forgot to rebase before last PR lol