### PR TITLE
Skip empty contexts when adding inputs

### DIFF
--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -203,7 +203,7 @@ def fetchInputSettings(filetext: str) -> List[Key]:
             line = line.strip()
             if line[0] == "[" and line[-1] == "]":
                 context = line
-            elif context != '':
+            elif context != '' and line != '':
                 found.append(Key(context, line))
     return found
 


### PR DESCRIPTION
Matching empty contexts breaks adding keys since there is no key to add with the context. This is just a hotfix to skip empty contexts when adding keys.

Relevant to #48 