### PR TITLE
Revert and rewrite input settings regex matching

### DIFF
--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -20,8 +20,7 @@ from src.util.util import (
 )
 
 XMLPATTERN = re.compile(r"<Var.+\/>", re.UNICODE)
-INPUTPATTERN = re.compile(
-    r"(\[.*\]\s*((IK_.+=\(Action=.+\)|Version=\d+)\s*)*\s*)+", re.UNICODE)
+INPUTPATTERN = re.compile(r"\[.*\]\s+(?:IK_.+=\(Action=.+\)\s*)+", re.UNICODE)
 USERPATTERN = re.compile(r"(\[.*\]\s*(.*=(?!.*(\(|\))).*\s*)+)+", re.UNICODE)
 INPUT_XML_PATTERN = r'id="PCInput".+<!--\s*\[BASE_CharacterMovement\]\s*-->'
 
@@ -194,9 +193,9 @@ def fetchAllXmlKeys(file: str, filetext: str, mod: Mod) -> None:
 
 def fetchInputSettings(filetext: str) -> List[Key]:
     found = []
-    inputsettings = INPUTPATTERN.search(filetext)
+    inputsettings = ''.join(INPUTPATTERN.findall(filetext))
     if (inputsettings):
-        res = re.sub(r"(\r\n+)|(\n+)", "\n", inputsettings.group(0))
+        res = re.sub(r"(\r\n+)|(\n+)", "\n", inputsettings)
         arr = filter(lambda s: s != '', str(res).split('\n'))
         context = ''
         for line in arr:


### PR DESCRIPTION
After some further testing, I realized that matching empty contexts (and the Version line) causes more problems than it fixes. The regex has been changed back to only matching contexts followed by valid key settings, but I have now fixed the core issue.  

The matching should use `re.findall()` instead of `re.search()` since the former matches all instances of a pattern instead of only the first. This allows us to skip empty contexts and other non-matching areas while keeping the valid matches.

Apologies for the last few bad commits, definitely should've thought about them more.

Hopefully, this fixes #48 for real this time