### PR TITLE
Re-add version and empty context matching in input settings installation

### DIFF
--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -21,7 +21,7 @@ from src.util.util import (
 
 XMLPATTERN = re.compile(r"<Var.+\/>", re.UNICODE)
 INPUTPATTERN = re.compile(
-    r"\[.+\]\s+(?:IK_.+=\(Action=.+\)\s|Version=\d+\s)+", re.UNICODE)
+    r"(?:\[.+\]\s+)(?:(?:IK_.+=\(Action=.+\)\s|Version=\d+\s)+)*", re.UNICODE)
 USERPATTERN = re.compile(r"(\[.*\]\s*(.*=(?!.*(\(|\))).*\s*)+)+", re.UNICODE)
 INPUT_XML_PATTERN = r'id="PCInput".+<!--\s*\[BASE_CharacterMovement\]\s*-->'
 
@@ -196,8 +196,7 @@ def fetchInputSettings(filetext: str) -> List[Key]:
     found = []
     inputsettings = ''.join(INPUTPATTERN.findall(filetext))
     if (inputsettings):
-        res = re.sub(r"(\r\n+)|(\n+)", "\n", inputsettings)
-        arr = filter(lambda s: s != '', str(res).split('\n'))
+        arr = inputsettings[:-1].split('\n')
         context = ''
         for line in arr:
             line = line.strip()

--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -199,21 +199,21 @@ def fetchInputSettings(filetext: str) -> List[Key]:
     if (inputsettings):
         arr = list(filter(lambda s: s != '', inputsettings.split('\n')))
         context = ''
-        count = 0
+        empty = False
         for line in arr:
             line = line.strip()
             if line[0] == "[" and line[-1] == "]":
-                if count == 0 and context != '':
+                if empty and context != '':
                     found.append(Key(context))
                 elif line == arr[-1]:
                     context = line
                     found.append(Key(context))
                     continue
                 context = line
-                count = 0
+                empty = False
             elif context != '':
                 found.append(Key(context, line))
-                count += 1
+                empty = True
     return found
 
 

--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -20,7 +20,8 @@ from src.util.util import (
 )
 
 XMLPATTERN = re.compile(r"<Var.+\/>", re.UNICODE)
-INPUTPATTERN = re.compile(r"\[.*\]\s+(?:IK_.+=\(Action=.+\)\s*)+", re.UNICODE)
+INPUTPATTERN = re.compile(
+    r"\[.+\]\s+(?:IK_.+=\(Action=.+\)\s|Version=\d+\s)+", re.UNICODE)
 USERPATTERN = re.compile(r"(\[.*\]\s*(.*=(?!.*(\(|\))).*\s*)+)+", re.UNICODE)
 INPUT_XML_PATTERN = r'id="PCInput".+<!--\s*\[BASE_CharacterMovement\]\s*-->'
 

--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -194,6 +194,7 @@ def fetchAllXmlKeys(file: str, filetext: str, mod: Mod) -> None:
 
 def fetchInputSettings(filetext: str) -> List[Key]:
     found = []
+    filetext = re.sub("r(\r\n)", "\n", filetext)
     inputsettings = ''.join(INPUTPATTERN.findall(filetext))
     if (inputsettings):
         arr = inputsettings.split('\n')

--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -199,7 +199,7 @@ def fetchInputSettings(filetext: str) -> List[Key]:
     if (inputsettings):
         arr = list(filter(lambda s: s != '', inputsettings.split('\n')))
         context = ''
-        empty = False
+        empty = True
         for line in arr:
             line = line.strip()
             if line[0] == "[" and line[-1] == "]":
@@ -210,10 +210,10 @@ def fetchInputSettings(filetext: str) -> List[Key]:
                     found.append(Key(context))
                     continue
                 context = line
-                empty = False
+                empty = True
             elif context != '':
                 found.append(Key(context, line))
-                empty = True
+                empty = False
     return found
 
 

--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -21,7 +21,7 @@ from src.util.util import (
 
 XMLPATTERN = re.compile(r"<Var.+\/>", re.UNICODE)
 INPUTPATTERN = re.compile(
-    r"\[.+\]\n(?:(?:IK_.+=\(Action=.+\)|Version=\d+)\n)*", re.UNICODE)
+    r"\[.+\]\s+(?:(?:IK_.+=\(Action=.+\)|Version=\d+)\s+)*", re.UNICODE)
 USERPATTERN = re.compile(r"(\[.*\]\s*(.*=(?!.*(\(|\))).*\s*)+)+", re.UNICODE)
 INPUT_XML_PATTERN = r'id="PCInput".+<!--\s*\[BASE_CharacterMovement\]\s*-->'
 

--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -21,7 +21,7 @@ from src.util.util import (
 
 XMLPATTERN = re.compile(r"<Var.+\/>", re.UNICODE)
 INPUTPATTERN = re.compile(
-    r"(?:\[.+\]\s+)(?:(?:IK_.+=\(Action=.+\)\s|Version=\d+\s)+)*", re.UNICODE)
+    r"(?:\[.+\]\s{1,2})(?:(?:IK_.+=\(Action=.+\)\s|Version=\d+\s)+)*", re.UNICODE)
 USERPATTERN = re.compile(r"(\[.*\]\s*(.*=(?!.*(\(|\))).*\s*)+)+", re.UNICODE)
 INPUT_XML_PATTERN = r'id="PCInput".+<!--\s*\[BASE_CharacterMovement\]\s*-->'
 
@@ -196,11 +196,13 @@ def fetchInputSettings(filetext: str) -> List[Key]:
     found = []
     inputsettings = ''.join(INPUTPATTERN.findall(filetext))
     if (inputsettings):
-        arr = inputsettings[:-1].split('\n')
+        arr = inputsettings.split('\n')
         context = ''
         for line in arr:
             line = line.strip()
-            if line[0] == "[" and line[-1] == "]":
+            if context != '' and line == '':
+                found.append(Key(context, line))
+            elif line[0] == "[" and line[-1] == "]":
                 context = line
             elif context != '':
                 found.append(Key(context, line))

--- a/src/domain/key.py
+++ b/src/domain/key.py
@@ -86,19 +86,27 @@ class Key:
 
     def __init__(self, context: str, key: str):
         self.context = context
-        self.key, action = key.split('=(')
-
-        self.action = Action(action)
-
-        if ("Pad" in self.key):
-            self.type = 'controller'
-        elif ('PS4' in self.key):
-            self.type = 'PS4'
+        if (key.startswith("Version")):
+            self.key = key
+            self.action = None
+            self.type = None
         else:
-            self.type = 'keyboard'
+            self.key, action = key.split('=(')
+
+            self.action = Action(action)
+
+            if ("Pad" in self.key):
+                self.type = 'controller'
+            elif ('PS4' in self.key):
+                self.type = 'PS4'
+            else:
+                self.type = 'keyboard'
 
     def __repr__(self):
-        return self.key + "=(" + repr(self.action) + ")"
+        if (self.key.startswith("Version")):
+            return self.key
+        else:
+            return self.key + "=(" + repr(self.action) + ")"
 
     def __eq__(self, other):
         return self.context == other.context \

--- a/src/domain/key.py
+++ b/src/domain/key.py
@@ -90,6 +90,10 @@ class Key:
             self.key = key
             self.action = None
             self.type = None
+        elif (key == ''):
+            self.key = '\n'
+            self.action = None
+            self.type = None
         else:
             self.key, action = key.split('=(')
 
@@ -103,7 +107,7 @@ class Key:
                 self.type = 'keyboard'
 
     def __repr__(self):
-        if (self.key.startswith("Version")):
+        if (self.key.startswith("Version") or self.key == '\n'):
             return self.key
         else:
             return self.key + "=(" + repr(self.action) + ")"

--- a/src/domain/key.py
+++ b/src/domain/key.py
@@ -83,18 +83,17 @@ class Key:
     key: str
     action: Action
     type: str
+    empty: bool
 
-    def __init__(self, context: str, key: str):
+    def __init__(self, context: str, key: str = ''):
         self.context = context
-        if (key.startswith("Version")):
+        if (key.startswith("Version") or key == ''):
             self.key = key
             self.action = None
             self.type = None
-        elif (key == ''):
-            self.key = '\n'
-            self.action = None
-            self.type = None
+            self.empty = (key == '')
         else:
+            self.empty = False
             self.key, action = key.split('=(')
 
             self.action = Action(action)
@@ -107,42 +106,49 @@ class Key:
                 self.type = 'keyboard'
 
     def __repr__(self):
-        if (self.key.startswith("Version") or self.key == '\n'):
+        if (self.key.startswith("Version")):
             return self.key
         else:
             return self.key + "=(" + repr(self.action) + ")"
 
     def __eq__(self, other):
-        return self.context == other.context \
-            and self.key == other.key \
-            and self.type == other.type \
-            and self.action == other.action
+        if not self.empty:
+            return self.context == other.context \
+                and self.key == other.key \
+                and self.type == other.type \
+                and self.action == other.action
+        else:
+            return False
 
     def __gt__(self, other):
         if self.context == other.context:
             if self.key == other.key:
-                return self.action > other.action
+                if not self.empty:
+                    return self.action > other.action
             return self.key > other.key
         return self.context > other.context
 
     def __lt__(self, other):
         if self.context == other.context:
             if self.key == other.key:
-                return self.action > other.action
+                if not self.empty:
+                    return self.action > other.action
             return self.key < other.key
         return self.context < other.context
 
     def __ge__(self, other):
         if self.context == other.context:
             if self.key == other.key:
-                return self.action > other.action
+                if not self.empty:
+                    return self.action > other.action
             return self.key >= other.key
         return self.context >= other.context
 
     def __le__(self, other):
         if self.context == other.context:
             if self.key == other.key:
-                return self.action > other.action
+                if not self.empty:
+                    return self.action > other.action
             return self.key <= other.key
         return self.context <= other.context
 

--- a/src/domain/mod.py
+++ b/src/domain/mod.py
@@ -283,7 +283,7 @@ class Mod:
             for key in iter(self.inputsettings):
                 if any(x for x in existing if x == key):
                     continue
-                conflicting = [x for x in existing if x.context == key.context and x.action["Action"] == key.action["Action"] and (
+                conflicting = [x for x in existing if not x.empty and x.context == key.context and x.action["Action"] == key.action["Action"] and (
                     (x.type == key.type and x.key != key.key) or
                     (x.key == key.key and x.action != key.action)
                 )]
@@ -331,7 +331,8 @@ class Mod:
                 if not category.endswith(']'):
                     text += ']'
                 text += '\n'
-            text += repr(key) + "\n"
+            if not key.empty:
+                text += repr(key) + "\n"
         with open(filename, 'w', encoding="utf-8") as userfile:
             userfile.write(text)
             userfile.flush()


### PR DESCRIPTION
As mentioned [here](https://github.com/Systemcluster/The-Witcher-3-Mod-manager/issues/48#issuecomment-2559785549) in #48, the game still resets input.settings if it doesn't find the input settings version. In addition, without the empty contexts there are bindings allowed that should not normally be allowed (ex: looking around while in pause menu).

<details>
<summary> Logic details for this PR if anyone is interested </summary>

- Regex changed to match a context, 1 or 2 whitespaces, an optional version, and as many as needed keybinds

- Lines fetched from the input.settings are then split on newlines (empty contexts will generate an additional empty 'key')

- Version key is treated specially when rewriting since it is not a 'real' key with actions, types, etc

- Empty keys are also treated specially when rewriting or checking for conflicts, sorting, etc

</details>