### PR TITLE
Fix `\r\n` substitution in input settings files.

### DIFF
--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -194,7 +194,7 @@ def fetchAllXmlKeys(file: str, filetext: str, mod: Mod) -> None:
 
 def fetchInputSettings(filetext: str) -> List[Key]:
     found = []
-    filetext = re.sub("r(\r\n+)|(\n+)", "\n", filetext)
+    filetext = re.sub(r"(\r\n+)|(\n+)", "\n", filetext)
     inputsettings = ''.join(INPUTPATTERN.findall(filetext))
     if (inputsettings):
         arr = list(filter(lambda s: s != '', inputsettings.split('\n')))


### PR DESCRIPTION
Turns out I made a typo that stops the `\r\n` substitution, breaking installation for files that have those kind of line breaks...