### PR TITLE
fix CheckState comparison to allow sorting by Enabled/Disabled

### DIFF
--- a/src/gui/tree_widget.py
+++ b/src/gui/tree_widget.py
@@ -15,7 +15,7 @@ class CustomTreeWidgetItem(QTreeWidgetItem):
     def __lt__(self, otherItem):
         column = self.treeWidget().sortColumn()
         if (not self.text(column) and not otherItem.text(column)):
-            return self.checkState(column) < otherItem.checkState(column)
+            return self.checkState(column).value < otherItem.checkState(column).value
         try:
             left = int(self.text(column)) if self.text(
                 column) != "-" else sys.maxsize


### PR DESCRIPTION
Hello! I noticed when trying to sort mods by the Enabled/Disabled column, an error would get logged and no sorting would occur, which I traced back to `Pyside6.QtCore.Qt.CheckState` not having direct comparisons implemented. From some quick inspection in the REPL, it looks like `CheckState` has a `value` field that returns the integer that the enum constant maps to, and updating the comparisons to use that seems to fix the issue.

I haven't written a lot of Python in recent years, so I don't have much more than a surface-level understanding of the library ecosystem and dependency management, but my instinct is that since the lockfile is checked into the repo, everyone will be using the same version of `PySide6`, so I don't think this fix should cause any issues. In case it matters though, here's the output of `pdm info --json`:

```{
  "pdm": {
    "version": "2.25.9"
  },
  "python": {
    "interpreter": "/home/saghm/code/forks/The-Witcher-3-Mod-Manager/.venv/bin/python",
    "version": "3.12",
    "markers": {
      "implementation_name": "cpython",
      "implementation_version": "3.12.11",
      "os_name": "posix",
      "platform_machine": "x86_64",
      "platform_release": "6.16.4-zen1-1-zen",
      "platform_system": "Linux",
      "platform_version": "#1 ZEN SMP PREEMPT_DYNAMIC Thu, 28 Aug 2025 19:49:40 +0000",
      "python_full_version": "3.12.11",
      "platform_python_implementation": "CPython",
      "python_version": "3.12",
      "sys_platform": "linux"
    }
  },
  "project": {
    "root": "/home/saghm/code/forks/The-Witcher-3-Mod-Manager",
    "pypackages": "/home/saghm/code/forks/The-Witcher-3-Mod-Manager/.venv/lib/python3.12/site-packages"
  }
}
```