### PR TITLE
fix: inputsettings regex fix once again

### DIFF
--- a/src/core/fetcher.py
+++ b/src/core/fetcher.py
@@ -21,7 +21,7 @@ from src.util.util import (
 
 XMLPATTERN = re.compile(r"<Var.+\/>", re.UNICODE)
 INPUTPATTERN = re.compile(
-    r"\[.+\]\s+(?:(?:IK_.+=\(Action=.+\)|Version=\d+)\s+)*", re.UNICODE)
+    r"\[.+\]\s+(?:(?:IK_.+=\(Action=.+\)|Version=\d+)\s*)*", re.UNICODE)
 USERPATTERN = re.compile(r"(\[.*\]\s*(.*=(?!.*(\(|\))).*\s*)+)+", re.UNICODE)
 INPUT_XML_PATTERN = r'id="PCInput".+<!--\s*\[BASE_CharacterMovement\]\s*-->'
 


### PR DESCRIPTION
Recently started modding again and came across a bug with the input settings importing (again). The mod's file did not have any whitespace/newline after the last key, so the regex failed and would not import the inputs.

Honestly not sure how this escaped me when I was actually working on and testing the code...