### PR TITLE
missing stringio import, not imported implicitly on some interpreters

### DIFF
--- a/src/core/model.py
+++ b/src/core/model.py
@@ -1,6 +1,7 @@
 '''Mod management model'''
 # pylint: disable=invalid-name,missing-docstring,wildcard-import,unused-wildcard-import
 
+from io import StringIO
 from typing import Dict, List, KeysView, ValuesView
 from os import path
 import re


### PR DESCRIPTION
found this when trying to run as a nix package out of https://github.com/colefuerth/dot-files/blob/main/packages/tw3mm.nix